### PR TITLE
Add 3rd param (false) to addEventListener.

### DIFF
--- a/lib/routie.js
+++ b/lib/routie.js
@@ -175,7 +175,7 @@
 
   var addListener = function() {
     if (w.addEventListener) {
-      w.addEventListener('hashchange', hashChanged);
+      w.addEventListener('hashchange', hashChanged, false);
     } else {
       w.attachEvent('onhashchange', hashChanged);
     }


### PR DESCRIPTION
Had a problem client using Firefox 3.6, which threw exceptions etc with not having 3 args to addEventListener. This fixes.
