### PR TITLE
Adding noConflict() method

### DIFF
--- a/lib/routie.js
+++ b/lib/routie.js
@@ -1,9 +1,9 @@
 (function(w) {
 
-  var routes = [],
-      map = {},
-      reference = "routie",
-      oldReference = w[reference];
+  var routes = [];
+  var map = {};
+  var reference = "routie";
+  var oldReference = w[reference];
 
   var Route = function(path, name) {
     this.name = name;


### PR DESCRIPTION
Routie create's a global object by default. When using a modular
framework like requirejs, there is no way to map the object to a module.
Adding noConflict() solves the issues. You could easily map the object
to any variable:

var app.router = routie.noConflict();

If using requirejs, adding a property in shim returns routie as a
module:

require.config({
paths: {
"router": "lib/routie",
},
shim: {
"router": {
init: function () {
return routie.noConflict();
}
}
}
});
