### PR TITLE
Support for dependency management (other than the "window" global)

### DIFF
--- a/lib/routie.js
+++ b/lib/routie.js
@@ -1,4 +1,14 @@
-(function(w) {
+(function (root, factory) {
+  if (typeof exports === 'object') {
+    module.exports = factory(window);
+  } else if (typeof define === 'function' && define.amd) {
+    define([], function () {
+      return (root.routie = factory(window));
+    });
+  } else {
+    root.routie = factory(window);
+  }
+}(this, function (w) {
 
   var routes = [];
   var map = {};
@@ -196,6 +206,5 @@
   };
   addListener();
 
-  w[reference] = routie;
-   
-})(window);
+  return routie;
+}));

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "routie",
   "version": "0.0.0",
   "private": true,
+  "main": "./lib/routie.js",
   "devDependencies": {
     "mocha": "~1.9.0",
     "grunt": "~0.4.1",


### PR DESCRIPTION
I'm using routie on a project that uses dependency management, with [Browserify](https://github.com/substack/node-browserify).

Up until now, I used it as a global (`window.routie`) but it would be better if it could be required by the modules that need it.

The pull request adds support for `require` (ex: Node.js) and `define` (ex. RequireJS). When included in the browser (`<script src="..." />`), it still adds itself to the window global.

The `noConflict` method should still work.
