### PR TITLE
Allow passing options through to routie.navigate()

### DIFF
--- a/lib/routie.js
+++ b/lib/routie.js
@@ -106,8 +106,8 @@
         addHandler(p, path[p]);
       }
       routie.reload();
-    } else if (typeof fn === 'undefined') {
-      routie.navigate(path);
+    } else if (typeof fn === 'undefined' || typeof fn == 'object') {
+      routie.navigate(path, fn);
     }
   };
 


### PR DESCRIPTION
This allows enabling silent option when updating a hash. e.g.:

routie('new_hash', {silent: true});
