### PR TITLE
Added unload function execution capabilities

### DIFF
--- a/lib/routie.js
+++ b/lib/routie.js
@@ -1,22 +1,27 @@
 (function(w) {
-
+  var currentRoute = null;
   var routes = [];
   var map = {};
   var reference = "routie";
   var oldReference = w[reference];
 
-  var Route = function(path, name) {
+  var Route = function(path, name, unloadFunction) {
     this.name = name;
     this.path = path;
     this.keys = [];
     this.fns = [];
     this.params = {};
+	  this.plainParams = [];
     this.regex = pathToRegexp(this.path, this.keys, false, false);
-
+    this.unloadFunction = unloadFunction;
   };
 
   Route.prototype.addHandler = function(fn) {
     this.fns.push(fn);
+  };
+  
+  Route.prototype.addUnload = function(fn){
+	this.unloadFunction = fn;  
   };
 
   Route.prototype.removeHandler = function(fn) {
@@ -30,9 +35,32 @@
   };
 
   Route.prototype.run = function(params) {
-    for (var i = 0, c = this.fns.length; i < c; i++) {
+	var that = this;
+	window.onbeforeunload = null;
+	if(that.unloadFunction !== null){
+	  window.onbeforeunload = function(ev){return that.runUnload(that.plainParams)};
+	}
+	
+	for (var i = 0, c = this.fns.length; i < c; i++) {
       this.fns[i].apply(this, params);
     }
+  };
+  
+  Route.prototype.runHashUnload = function(params){
+	if(this.unloadFunction === null){
+	  return true;	
+	} else {
+	  var text = this.unloadFunction.apply(this, params);   
+	  if(text !== null && text !== '' && text !== undefined && typeof text === "string"){
+	    return confirm(text);	
+	  }	else {
+		return true;  
+	  }
+	}
+  };
+  
+  Route.prototype.runUnload = function(params){
+	return this.unloadFunction.apply(this, params);  
   };
 
   Route.prototype.match = function(path, params){
@@ -51,7 +79,7 @@
       }
       params.push(val);
     }
-
+	this.plainParams = params;
     return true;
   };
 
@@ -85,25 +113,39 @@
     return new RegExp('^' + path + '$', sensitive ? '' : 'i');
   };
 
-  var addHandler = function(path, fn) {
+  var addHandler = function(path, fn, unloadDialogs) {
     var s = path.split(' ');
     var name = (s.length == 2) ? s[0] : null;
     path = (s.length == 2) ? s[1] : s[0];
 
     if (!map[path]) {
-      map[path] = new Route(path, name);
+      map[path] = new Route(path, name, matchUnloadFunction(path, unloadDialogs));
       routes.push(map[path]);
     }
     map[path].addHandler(fn);
   };
 
-  var routie = function(path, fn) {
+  var matchUnloadFunction = function(path, unloadDialogs){
+	var unloadFunction = null;
+	
+	if(!unloadDialogs){
+	  return unloadFunction;	
+	}
+	
+	if(unloadDialogs.hasOwnProperty(path)){
+	  unloadFunction = 	unloadDialogs[path];
+	}
+	
+	return unloadFunction;
+  };
+
+  var routie = function(path, fn, unload) {
     if (typeof fn == 'function') {
-      addHandler(path, fn);
+      addHandler(path, fn, unload);
       routie.reload();
-    } else if (typeof path == 'object') {
+    } else if (typeof path == 'object') {;
       for (var p in path) {
-        addHandler(p, path[p]);
+        addHandler(p, path[p], fn);
       }
       routie.reload();
     } else if (typeof fn === 'undefined') {
@@ -163,13 +205,39 @@
   var checkRoute = function(hash, route) {
     var params = [];
     if (route.match(hash, params)) {
-      route.run(params);
-      return true;
+	  // runit is a parameter which flags wether the Route should run or not.
+	  // when the hash of the currentRoute is the same as the window.hash then we don't have to run the route again	
+      var runit = false;
+	  if(!currentRoute){
+		runit = true;  
+	  } else {
+		if(currentRoute.hash !== getHash()){ // avoid unload function execution when coming back from return false unload
+		  runit = true;
+		}
+	  }
+	
+      if(runit){
+		  currentRoute = route;
+		  route.hash = hash;
+		  route.run(params);
+		  return true;
+	  } else {
+	      return false;  
+	  }
     }
     return false;
   };
 
   var hashChanged = routie.reload = function() {
+	if(currentRoute){
+	  if(currentRoute.hash !== getHash()){ // avoid unload function execution when coming back from return false unload
+		  if(!currentRoute.runHashUnload(currentRoute.plainParams)){
+			window.location.replace('#' + currentRoute.toURL(currentRoute.params));
+			return false;  
+		  }
+	  }
+	}
+	
     var hash = getHash();
     for (var i = 0, c = routes.length; i < c; i++) {
       var route = routes[i];


### PR DESCRIPTION
With the proposed addition the user can add an extra parameter when initializing routie so that an unload function is been executed when the user leaves a specific hash page.
The unload function is also been executed when the user leaves page or closes his browser (window.onbeforeunload event).
The way it operates is simple. Let's suppose the following example:
routie({
  'apage/:id': function(id) {  
      /\* handles the load part _/  
    }
  }, // here the classic routie operation ends and the new starts
  { // we define unload functions in exact the same way
    'apage/:id': function(id) { 
      /_ here we can write any code. This code will be executed when the user leaves the hash or actual page.
     if the function returns a string then this string will be used for exit page confirmation either when the user goes to another hash or another physical page. If the function returns anything else but string (or nothing at all) no confirmation message will appear. Only the code will be executed */  
    }
  } // the unload functions part ends. We don't have to declare functions for all of our hashes. Only for those for which we want an unload function to be executed.
); // routie ends
