### PR TITLE
Added routie.load()

### DIFF
--- a/lib/routie.js
+++ b/lib/routie.js
@@ -155,6 +155,10 @@
     w[reference] = oldReference;
     return routie;
   };
+  
+  routie.load = function(path) {
+    map[path].run();
+  };
 
   var getHash = function() {
     return window.location.hash.substring(1);


### PR DESCRIPTION
Added routie.load() to allow forced reloads from outside the closure.

Since I couldn't figure out any other way to force a reload without changing the actual hash I've introduced the load function (naming was inspired by jQuery.routes). If there's another way which does not require this change I'd love to know about it, otherwise it may be a great addition.
