### PR TITLE
Add IE7 support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,8 @@ None
 
 ##Supports
 
-Any modern browser and IE8+
+Any modern browser and IE7+
 
 ##Tests
 
 Run `make install`, then `make test`, then go to http://localhost:8000/test
-

--- a/lib/routie.js
+++ b/lib/routie.js
@@ -4,6 +4,7 @@
   var map = {};
   var reference = "routie";
   var oldReference = w[reference];
+  var pollInterval = null;
 
   var Route = function(path, name) {
     this.name = name;
@@ -143,7 +144,7 @@
       window.location.hash = path;
 
       if (silent) {
-        setTimeout(function() { 
+        setTimeout(function() {
           addListener();
         }, 1);
       }
@@ -180,7 +181,22 @@
   };
 
   var addListener = function() {
-    if (w.addEventListener) {
+    if (!('onhashchange' in w)) {
+      var oldHref = location.href;
+      pollInterval = setInterval(function() {
+        var newHref = location.href;
+        if (oldHref !== newHref) {
+          var _oldHref = oldHref;
+          oldHref = newHref;
+
+          hashChanged.call(window, {
+            'type': 'hashchange',
+            'newURL': newHref,
+            'oldURL': _oldHref
+          });
+        }
+      }, 100);
+    } else if (w.addEventListener) {
       w.addEventListener('hashchange', hashChanged, false);
     } else {
       w.attachEvent('onhashchange', hashChanged);
@@ -188,7 +204,10 @@
   };
 
   var removeListener = function() {
-    if (w.removeEventListener) {
+    if (!('onhashchange' in w)) {
+      clearInterval(pollInterval);
+      pollInterval = null;
+    } else if (w.removeEventListener) {
       w.removeEventListener('hashchange', hashChanged);
     } else {
       w.detachEvent('onhashchange', hashChanged);
@@ -197,5 +216,5 @@
   addListener();
 
   w[reference] = routie;
-   
+
 })(window);


### PR DESCRIPTION
I really like this library but I needed to support IE7 so I modified it to work.

* Poll the window hash for changes when there is no `hashChange` event available.
* Update the README.md to indicate the library supports IE7+.