### PR TITLE
Update documentation for optional parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ routie('users/bob');
 
 optional params:
 ```js
-routie('users/?:name', function(name) {
+routie('users/:name?', function(name) {
 	//name == undefined
 	//then
 	//name == bob


### PR DESCRIPTION
This updates the documentation where the optional parameter was described as `users/?:name`, but it has to be `users/:name?` in order to work.
This fixes #27.